### PR TITLE
PowerKeys Single Keystroke Remapping

### DIFF
--- a/installer/MSIX/PackagingLayout.xml
+++ b/installer/MSIX/PackagingLayout.xml
@@ -15,6 +15,7 @@
         <File DestinationPath="modules\Microsoft.Xaml.Behaviors.dll" SourcePath="..\..\x64\Release\modules\Microsoft.Xaml.Behaviors.dll"/>
         <File DestinationPath="modules\PowerRenameExt.dll" SourcePath="..\..\x64\Release\modules\PowerRenameExt.dll"/>
         <File DestinationPath="modules\shortcut_guide.dll" SourcePath="..\..\x64\Release\modules\shortcut_guide.dll"/>
+        <File DestinationPath="modules\PowerKeys.dll" SourcePath="..\..\x64\Release\modules\PowerKeys.dll"/>
         <File DestinationPath="modules\PowerRenameUWPUI.exe" SourcePath="..\..\x64\Release\PowerRenameUWPUI.exe"/>
         <File DestinationPath="Notifications.dll" SourcePath="..\..\x64\Release\Notifications.dll"/>
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
This code actively remaps single keystrokes and can change a key from toggle to modifier behavior.
The keys to be remapped are hardcoded in the PowerKeys constructor.

To use:
Run PowerToys and Enable PowerKeys for remapping to take place and disable for resetting it.