### PR TITLE
PowerKeys: Registry approach Proof of Concept

### DIFF
--- a/installer/MSIX/PackagingLayout.xml
+++ b/installer/MSIX/PackagingLayout.xml
@@ -14,6 +14,7 @@
         <File DestinationPath="modules\MahApps.Metro.dll" SourcePath="..\..\x64\Release\modules\MahApps.Metro.dll"/>
         <File DestinationPath="modules\Microsoft.Xaml.Behaviors.dll" SourcePath="..\..\x64\Release\modules\Microsoft.Xaml.Behaviors.dll"/>
         <File DestinationPath="modules\PowerRenameExt.dll" SourcePath="..\..\x64\Release\modules\PowerRenameExt.dll"/>
+        <File DestinationPath="modules\PowerKeys.dll" SourcePath="..\..\x64\Release\modules\PowerKeys.dll"/>
         <File DestinationPath="modules\shortcut_guide.dll" SourcePath="..\..\x64\Release\modules\shortcut_guide.dll"/>
         <File DestinationPath="modules\PowerRenameUWPUI.exe" SourcePath="..\..\x64\Release\PowerRenameUWPUI.exe"/>
         <File DestinationPath="Notifications.dll" SourcePath="..\..\x64\Release\Notifications.dll"/>

--- a/src/modules/PowerKeys/dllmain.cpp
+++ b/src/modules/PowerKeys/dllmain.cpp
@@ -265,6 +265,7 @@ public:
         {
             if (flag)
             {
+                // Disabling the [{ key (has scan code 0x1A)
                 BYTE regVal[] = { 00, 00, 00, 00, 00, 00, 00, 00, 0x02, 00, 00, 00, 00, 00, 0x1A, 00, 00, 00, 00, 00 };
                 lRet = RegSetValueEx(hKey, L"Scancode Map", NULL, REG_BINARY, (BYTE*)regVal, 20);
                 if (lRet == ERROR_SUCCESS)
@@ -274,6 +275,7 @@ public:
             }
             else
             {
+                // Resetting the remaps
                 lRet = RegDeleteValue(hKey, L"Scancode Map");
                 if (lRet == ERROR_SUCCESS)
                 {

--- a/src/modules/PowerKeys/dllmain.cpp
+++ b/src/modules/PowerKeys/dllmain.cpp
@@ -215,12 +215,14 @@ public:
     virtual void enable()
     {
         m_enabled = true;
+        registry_method(m_enabled);
     }
 
     // Disable the powertoy
     virtual void disable()
     {
         m_enabled = false;
+        registry_method(m_enabled);
     }
 
     // Returns if the powertoys is enabled
@@ -253,6 +255,34 @@ public:
 
     virtual void signal_system_menu_action(const wchar_t* name) override {}
 
+    // flag = true for enabled
+    bool registry_method(bool flag)
+    {
+        HKEY hKey;
+        LONG lRet, lRetOpen;
+        lRetOpen = RegOpenKeyEx(HKEY_LOCAL_MACHINE, L"System\\CurrentControlSet\\Control\\Keyboard Layout", 0, KEY_WRITE, &hKey);
+        if (lRetOpen == ERROR_SUCCESS)
+        {
+            if (flag)
+            {
+                BYTE regVal[] = { 00, 00, 00, 00, 00, 00, 00, 00, 0x02, 00, 00, 00, 00, 00, 0x1A, 00, 00, 00, 00, 00 };
+                lRet = RegSetValueEx(hKey, L"Scancode Map", NULL, REG_BINARY, (BYTE*)regVal, 20);
+                if (lRet == ERROR_SUCCESS)
+                {
+                    return true;
+                }
+            }
+            else
+            {
+                lRet = RegDeleteValue(hKey, L"Scancode Map");
+                if (lRet == ERROR_SUCCESS)
+                {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
 };
 
 // This method of saving the module settings is only required if you need to do any


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Implemented code to add/remove the Scancode Map registry value for disabling the "[{" key (scancode 0x1A). The registry entry can be added/removed by enabling/disabling PowerKeys.
It works on both non-MSIX and MSIX when run as admin.
