### PR TITLE
App Specific shortcut remapping

### DIFF
--- a/src/modules/PowerKeys/PowerKeys.vcxproj
+++ b/src/modules/PowerKeys/PowerKeys.vcxproj
@@ -96,6 +96,12 @@
     <ClCompile>
       <AdditionalIncludeDirectories>$(SolutionDir)src\;$(SolutionDir)src\modules;$(SolutionDir)src\common\Telemetry;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
+    <Link>
+      <AdditionalDependencies Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">shlwapi.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+    <Link>
+      <AdditionalDependencies Condition="'$(Configuration)|$(Platform)'=='Release|x64'">shlwapi.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClInclude Include="pch.h" />

--- a/src/modules/PowerKeys/pch.h
+++ b/src/modules/PowerKeys/pch.h
@@ -3,3 +3,4 @@
 #include <windows.h>
 #include <common/common.h>
 #include <ProjectTelemetry.h>
+#include <shlwapi.h>


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
This PR adds app specific shortcut support. It works by identify the current foreground window using the GetGUIThreadInfo API and retrieving the process ID of that thread.
The following shortcuts are added in addition to the key remaps and os level shortcuts added previously:
- Edge Beta: Ctrl+C to Ctrl+V
- Outlook: Ctrl+F to Ctrl+E (Ctrl+F does find after remapping)
- Edge: Ctrl+X to Ctrl+V
- Calculator: Ctrl+G to Shift+2 (Ctrl+G will do square root)
