### PR TITLE
PowerKeys Backend demo

### DIFF
--- a/src/modules/PowerKeys/dllmain.cpp
+++ b/src/modules/PowerKeys/dllmain.cpp
@@ -99,6 +99,7 @@ public:
 
         //App-specific shortcut remappings
         appSpecificShortcutReMap[L"msedge.exe"][std::vector<DWORD>({ VK_LCONTROL, 0x43 })] = std::make_pair(std::vector<WORD>({ VK_LCONTROL, 0x56 }), false); // Ctrl+C to Ctrl+V
+        appSpecificShortcutReMap[L"msedge.exe"][std::vector<DWORD>({ VK_LMENU, 0x44 })] = std::make_pair(std::vector<WORD>({ VK_LCONTROL, 0x46 }), false); // Alt+D to Ctrl+F
         appSpecificShortcutReMap[L"OUTLOOK.EXE"][std::vector<DWORD>({ VK_LCONTROL, 0x46 })] = std::make_pair(std::vector<WORD>({ VK_LCONTROL, 0x45 }), false); // Ctrl+F to Ctrl+E
         appSpecificShortcutReMap[L"MicrosoftEdge.exe"][std::vector<DWORD>({ VK_LCONTROL, 0x58 })] = std::make_pair(std::vector<WORD>({ VK_LCONTROL, 0x56 }), false); // Ctrl+X to Ctrl+V
         appSpecificShortcutReMap[L"Calculator.exe"][std::vector<DWORD>({ VK_LCONTROL, 0x47 })] = std::make_pair(std::vector<WORD>({ VK_LSHIFT, 0x32 }), false); // Ctrl+G to Shift+2

--- a/src/modules/PowerKeys/dllmain.cpp
+++ b/src/modules/PowerKeys/dllmain.cpp
@@ -61,7 +61,7 @@ private:
     static const ULONG_PTR POWERKEYS_INJECTED_FLAG = 0x1;
     static const ULONG_PTR POWERKEYS_SINGLEKEY_FLAG = 0x11;
     static const ULONG_PTR POWERKEYS_SHORTCUT_FLAG = 0x101;
-    static const DWORD DUMMY_KEY = 0xCF;
+    static const DWORD DUMMY_KEY = 0xFF;
     static HHOOK hook_handle;
     static HHOOK hook_handle_copy; // make sure we do use nullptr in CallNextHookEx call
     static PowerKeys* powerkeys_object_ptr;


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Fixed bugs related to interaction between single key remappings and shortcut remapping and added priority for single key remappings and app specific shortcuts over os level shortcuts.
The following remappings are done:
**Single Key Remapping**
- Disable [ key
- Change Caps Lock from toggle to modifier
- Swap Windows (left) key and Ctrl (left) key

**OS Level Shortcut Remapping** (All modifiers below are left only)
- Alt+E remapped to Ctrl+X
- Alt+D remapped to Ctrl+V
- Win+A remapped to Ctrl+X
- Ctrl+X remapped to Alt+D
- Ctrl+V remapped to Win+A
(Last 4 tests circular references)

**App Specific Shortcut Remapping** (All modifiers below are left only)
- msedge.exe (New Edge Beta): Ctrl+C remapped to Ctrl+V, Alt+D to Ctrl+F (second one is to verify that app specific overrides global)
- Outlook: Ctrl+F remapped to Ctrl+E
- Old Edge: Ctrl+X remapped to Ctrl+V
- Calculator: Ctrl+G remapped to Shift+2 (does square root)

### Known Issues
- Interaction with Shortcut Guide
- Win+L remapping doesn't work
- App specific shortcut for Old Edge works only on the address bar (issue related to multiple executables being used for the GUI on different parts of the window).